### PR TITLE
Add editable metadata to data model.

### DIFF
--- a/neverpile-fusion-core/src/main/java/com/neverpile/fusion/model/CollectionType.java
+++ b/neverpile-fusion-core/src/main/java/com/neverpile/fusion/model/CollectionType.java
@@ -33,6 +33,11 @@ public class CollectionType {
   private List<String> permittedTags;
 
   /**
+   * Defined editable metadata for creating and editing of elements.
+   */
+  private EditableMetadata editableMetadata;
+
+  /**
    * Whether to allow arbitrary tags in addition to the ones defined in {@link #permittedTags}.
    */
   private boolean allowAllTags;
@@ -83,6 +88,15 @@ public class CollectionType {
   public void setPermittedTags(final List<String> tags) {
     this.permittedTags = tags;
   }
+
+  public EditableMetadata getEditableMetadata() {
+    return editableMetadata;
+  }
+
+  public void setEditableMetadata(EditableMetadata editableMetadata) {
+    this.editableMetadata = editableMetadata;
+  }
+
 
   public boolean isAllowAllTags() {
     return allowAllTags;

--- a/neverpile-fusion-core/src/main/java/com/neverpile/fusion/model/EditableMetadata.java
+++ b/neverpile-fusion-core/src/main/java/com/neverpile/fusion/model/EditableMetadata.java
@@ -1,0 +1,56 @@
+package com.neverpile.fusion.model;
+
+/**
+ * Defined editable metadata for creating and editing of elements.
+ */
+public class EditableMetadata {
+  /**
+   * The list of editable metadata when creating new elements.
+   */
+  EditableMetadataEntry[] create;
+
+  /**
+   * The list of editable metadata when editing existing elements.
+   */
+  EditableMetadataEntry[] edit;
+
+  public EditableMetadataEntry[] getCreate() {
+    return create;
+  }
+
+  public void setCreate(EditableMetadataEntry[] create) {
+    this.create = create;
+  }
+
+  public EditableMetadataEntry[] getEdit() {
+    return edit;
+  }
+
+  public void setEdit(EditableMetadataEntry[] edit) {
+    this.edit = edit;
+  }
+
+  /**
+   * Metadata element containing the property key and a corresponding label.
+   */
+  public static class EditableMetadataEntry {
+    String key;
+    String label;
+
+    public String getKey() {
+      return key;
+    }
+
+    public void setKey(String key) {
+      this.key = key;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    public void setLabel(String label) {
+      this.label = label;
+    }
+  }
+}

--- a/neverpile-fusion-core/src/main/resources/com/neverpile/fusion/fusion-core.yaml
+++ b/neverpile-fusion-core/src/main/resources/com/neverpile/fusion/fusion-core.yaml
@@ -657,6 +657,34 @@ components:
           items:
             type: string
             pattern: '[\w .-_/]+'
+        editableMetadata:
+          type: object
+          description: Defined editable metadata for creating and editing of elements.
+          properties:
+            create:
+              type: array
+              description: The list of editable metadata when creating new elements.
+              items:
+                type: object
+                description: Metadata element containing the property key and a corresponding label.
+                properties:
+                  key:
+                    type: string
+                    pattern: '^(?![0-9])[a-zA-Z0-9.]+$'
+                  label:
+                    type: string
+            edit:
+              type: array
+              description: The list of editable metadata when editing existing elements.
+              items:
+                type: object
+                description: Metadata element containing the property key and a corresponding label.
+                properties:
+                  key:
+                    type: string
+                    pattern: '^(?![0-9])[a-zA-Z0-9.]+$'
+                  label:
+                    type: string
         allowAllTags:
           type: boolean
           description: Whether to allow arbitrary tags in addition to the ones defined in `permittedTags`.

--- a/neverpile-fusion-core/src/test/java/com/neverpile/fusion/impl/ResourcePathCollectionTypeServiceTest.java
+++ b/neverpile-fusion-core/src/test/java/com/neverpile/fusion/impl/ResourcePathCollectionTypeServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.neverpile.fusion.configuration.JacksonConfiguration;
 import com.neverpile.fusion.model.CollectionType;
+import com.neverpile.fusion.model.EditableMetadata;
 import com.neverpile.fusion.model.View;
 import com.neverpile.fusion.model.rules.javascript.JavascriptRule;
 
@@ -72,6 +73,22 @@ public class ResourcePathCollectionTypeServiceTest {
 
     t.setId("aCollectionType");
     t.setPermittedTags(Arrays.asList("foo", "bar", "baz"));
+
+    EditableMetadata editableMetadata = new EditableMetadata();
+    EditableMetadata.EditableMetadataEntry[] edit = new EditableMetadata.EditableMetadataEntry[1];
+    edit[0] = new EditableMetadata.EditableMetadataEntry();
+    edit[0].setKey("foo.bar");
+    edit[0].setLabel("test");
+    editableMetadata.setEdit(edit);
+    EditableMetadata.EditableMetadataEntry[] create = new EditableMetadata.EditableMetadataEntry[2];
+    create[0] = new EditableMetadata.EditableMetadataEntry();
+    create[0].setKey("foo.bar");
+    create[0].setLabel("test");
+    create[1] = new EditableMetadata.EditableMetadataEntry();
+    create[1].setKey("foo.baz");
+    create[1].setLabel("test2");
+    editableMetadata.setCreate(create);
+    t.setEditableMetadata(editableMetadata);
     t.setName("A very basic collection type");
     t.setDescription("A collection type used to test fusion");
 

--- a/neverpile-fusion-core/src/test/resources/collectionTypes/aJsonCollectionType.json
+++ b/neverpile-fusion-core/src/test/resources/collectionTypes/aJsonCollectionType.json
@@ -3,6 +3,19 @@
   "name" : "A very basic collection type",
   "description" : "A collection type used to test fusion",
   "permittedTags" : [ "foo", "bar", "baz" ],
+  "editableMetadata" : {
+    "create" : [ {
+      "key" : "foo.bar",
+      "label" : "test"
+    }, {
+      "key" : "foo.baz",
+      "label" : "test2"
+    } ],
+    "edit" : [ {
+      "key" : "foo.bar",
+      "label" : "test"
+    } ]
+  },
   "allowAllTags" : false,
   "views" : [ {
     "name" : "Default",

--- a/neverpile-fusion-core/src/test/resources/collectionTypes/aYamlCollectionType.yaml
+++ b/neverpile-fusion-core/src/test/resources/collectionTypes/aYamlCollectionType.yaml
@@ -6,6 +6,15 @@ permittedTags:
 - foo
 - bar
 - baz
+editableMetadata:
+  create:
+    - key: foo.bar
+      label: test
+    - key: foo.baz
+      label: test2
+  edit:
+    - key: foo.bar
+      label: test
 allowAllTags: false
 views:
 - name: Default


### PR DESCRIPTION
This can be tested and is made for https://github.com/levigo/neverpile-fusion-web-client/pull/136

Adds configurable and editable metadata to the data model. 
Differentiates between edit and create.