### PR TITLE
Add render settings to data model.

### DIFF
--- a/neverpile-fusion-core/src/main/java/com/neverpile/fusion/model/spec/CompositePaged.java
+++ b/neverpile-fusion-core/src/main/java/com/neverpile/fusion/model/spec/CompositePaged.java
@@ -44,6 +44,11 @@ public class CompositePaged extends Specification {
      */
     private JsonNode annotationData;
 
+    /**
+     * Render settings data on a per-page-sequence basis.
+     */
+    private JsonNode renderSettingsData;
+
     public MediaType getMediaType() {
       return mediaType;
     }
@@ -74,6 +79,14 @@ public class CompositePaged extends Specification {
 
     public void setAnnotationData(final JsonNode annotationData) {
       this.annotationData = annotationData;
+    }
+
+    public JsonNode getRenderSettingsData() {
+      return renderSettingsData;
+    }
+
+    public void setRenderSettingsData(final JsonNode renderSettingsData) {
+      this.renderSettingsData = renderSettingsData;
     }
   }
 

--- a/neverpile-fusion-core/src/main/resources/com/neverpile/fusion/fusion-core.yaml
+++ b/neverpile-fusion-core/src/main/resources/com/neverpile/fusion/fusion-core.yaml
@@ -622,6 +622,24 @@ components:
                           minimum: 0
                       annotationData:
                         $ref: "#/components/schemas/AnnotationData"
+                      renderSettingsData:
+                        type: object
+                        nullable: true
+                        description: Render settings data for the page Sequence.
+                        properties:
+                          pageRenderSettingsData:
+                            type: array
+                            description: Render settings data per page.
+                            items:
+                              type: object
+                              description: Render settings data for a single page.
+                              properties:
+                                pageIndex:
+                                  description: Index of the annotated Page in the Sequence.
+                                  type: number
+                                serializedPageRenderSettings:
+                                  description: Serialized Render Inormation.
+                                  type: string
     AnnotationData:
       description: Annotations are markings, textual notes or other forms of supplementary information added to a
         paged document that can be applied by a user without changing the underlying document information. Anotations

--- a/neverpile-fusion-core/src/test/java/com/neverpile/fusion/model/JsonMappingTest.java
+++ b/neverpile-fusion-core/src/test/java/com/neverpile/fusion/model/JsonMappingTest.java
@@ -24,72 +24,76 @@ import com.neverpile.fusion.model.spec.CompositePaged;
 import com.neverpile.fusion.model.spec.CompositePaged.PageSequence;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = WebEnvironment.NONE, classes = {JacksonAutoConfiguration.class, JacksonConfiguration.class})
+@SpringBootTest(webEnvironment = WebEnvironment.NONE,
+    classes = {JacksonAutoConfiguration.class, JacksonConfiguration.class})
 public class JsonMappingTest {
   @Autowired
   private ObjectMapper objectMapper;
-  
-  private final String REF = "{\r\n" + 
-      "  \"id\" : \"anId\",\r\n" + 
-      "  \"versionTimestamp\" : \"1970-01-01T00:00:00.001Z\",\r\n" + 
-      "  \"state\" : \"Active\",\r\n" + 
-      "  \"dateCreated\" : \"1970-01-01T00:00:00.001Z\",\r\n" + 
-      "  \"dateModified\" : \"1970-01-01T00:00:00.001Z\",\r\n" + 
-      "  \"createdBy\" : \"user\",\r\n" + 
-      "  \"metadata\" : {\r\n" + 
-      "    \"foo\" : \"bar\"\r\n" + 
-      "  },\r\n" + 
-      "  \"elements\" : [ {\r\n" + 
-      "    \"id\" : \"anElementId\",\r\n" + 
-      "    \"dateCreated\" : \"1970-01-01T00:00:00.001Z\",\r\n" + 
-      "    \"dateModified\" : \"1970-01-01T00:00:00.001Z\",\r\n" + 
-      "    \"tags\" : [ \"foo\", \"bar\" ],\r\n" + 
-      "    \"metadata\" : {\r\n" + 
-      "      \"foo\" : \"baz\"\r\n" + 
-      "    },\r\n" + 
-      "    \"specification\" : {\r\n" + 
-      "      \"type\" : \"artifact\",\r\n" + 
-      "      \"contentURI\" : \"text:collection:from://some/where\",\r\n" + 
-      "      \"mediaType\" : \"text/plain\"\r\n" + 
-      "    }\r\n" + 
-      "  }, {\r\n" + 
-      "    \"id\" : \"anotherElementId\",\r\n" + 
-      "    \"dateCreated\" : \"1970-01-01T00:00:00.001Z\",\r\n" + 
-      "    \"dateModified\" : \"1970-01-01T00:00:00.001Z\",\r\n" + 
-      "    \"tags\" : [ \"foo\", \"bar\" ],\r\n" + 
-      "    \"metadata\" : {\r\n" + 
-      "      \"foo\" : \"baz\"\r\n" + 
-      "    },\r\n" + 
-      "    \"specification\" : {\r\n" + 
-      "      \"type\" : \"compositePaged\",\r\n" + 
-      "      \"pageSequences\" : [ {\r\n" + 
-      "        \"mediaType\" : \"application/pdf\",\r\n" + 
-      "        \"contentURI\" : \"pdf:from://some/where\",\r\n" + 
-      "        \"pageIndices\" : [ 0, 1, 2 ],\r\n" + 
-      "        \"annotationData\" : null\r\n" + 
-      "      }, {\r\n" + 
-      "        \"mediaType\" : \"image/jpeg\",\r\n" + 
-      "        \"contentURI\" : \"jpg:from://some/where\",\r\n" + 
-      "        \"pageIndices\" : [ 0 ],\r\n" + 
-      "        \"annotationData\" : null\r\n" + 
-      "      }, {\r\n" + 
-      "        \"mediaType\" : \"image/tiff\",\r\n" + 
-      "        \"contentURI\" : \"tiff:from://some/where\",\r\n" + 
-      "        \"pageIndices\" : [ 3, 4, 5 ],\r\n" + 
-      "        \"annotationData\" : null\r\n" + 
-      "      } ],\r\n" + 
-      "      \"annotationData\" : null\r\n" + 
-      "    }\r\n" + 
-      "  } ],\r\n" + 
-      "  \"typeId\" : \"aCollectionType\"\r\n" + 
+
+  private final String REF = "{\r\n" + //
+      "  \"id\" : \"anId\",\r\n" + //
+      "  \"versionTimestamp\" : \"1970-01-01T00:00:00.001Z\",\r\n" + //
+      "  \"state\" : \"Active\",\r\n" + //
+      "  \"dateCreated\" : \"1970-01-01T00:00:00.001Z\",\r\n" + //
+      "  \"dateModified\" : \"1970-01-01T00:00:00.001Z\",\r\n" + //
+      "  \"createdBy\" : \"user\",\r\n" + //
+      "  \"metadata\" : {\r\n" + //
+      "    \"foo\" : \"bar\"\r\n" + //
+      "  },\r\n" + //
+      "  \"elements\" : [ {\r\n" + //
+      "    \"id\" : \"anElementId\",\r\n" + //
+      "    \"dateCreated\" : \"1970-01-01T00:00:00.001Z\",\r\n" + //
+      "    \"dateModified\" : \"1970-01-01T00:00:00.001Z\",\r\n" + //
+      "    \"tags\" : [ \"foo\", \"bar\" ],\r\n" + //
+      "    \"metadata\" : {\r\n" + //
+      "      \"foo\" : \"baz\"\r\n" + //
+      "    },\r\n" + //
+      "    \"specification\" : {\r\n" + //
+      "      \"type\" : \"artifact\",\r\n" + //
+      "      \"contentURI\" : \"text:collection:from://some/where\",\r\n" + //
+      "      \"mediaType\" : \"text/plain\"\r\n" + //
+      "    }\r\n" + //
+      "  }, {\r\n" + //
+      "    \"id\" : \"anotherElementId\",\r\n" + //
+      "    \"dateCreated\" : \"1970-01-01T00:00:00.001Z\",\r\n" + //
+      "    \"dateModified\" : \"1970-01-01T00:00:00.001Z\",\r\n" + //
+      "    \"tags\" : [ \"foo\", \"bar\" ],\r\n" + //
+      "    \"metadata\" : {\r\n" + //
+      "      \"foo\" : \"baz\"\r\n" + //
+      "    },\r\n" + //
+      "    \"specification\" : {\r\n" + //
+      "      \"type\" : \"compositePaged\",\r\n" + //
+      "      \"pageSequences\" : [ {\r\n" + //
+      "        \"mediaType\" : \"application/pdf\",\r\n" + //
+      "        \"contentURI\" : \"pdf:from://some/where\",\r\n" + //
+      "        \"pageIndices\" : [ 0, 1, 2 ],\r\n" + //
+      "        \"annotationData\" : null,\r\n" + //
+      "        \"renderSettingsData\" : null\r\n" + //
+      "      }, {\r\n" + //
+      "        \"mediaType\" : \"image/jpeg\",\r\n" + //
+      "        \"contentURI\" : \"jpg:from://some/where\",\r\n" + //
+      "        \"pageIndices\" : [ 0 ],\r\n" + //
+      "        \"annotationData\" : null,\r\n" + //
+      "        \"renderSettingsData\" : null\r\n" + //
+      "      }, {\r\n" + //
+      "        \"mediaType\" : \"image/tiff\",\r\n" + //
+      "        \"contentURI\" : \"tiff:from://some/where\",\r\n" + //
+      "        \"pageIndices\" : [ 3, 4, 5 ],\r\n" + //
+      "        \"annotationData\" : null,\r\n" + //
+      "        \"renderSettingsData\" : null\r\n" + //
+      "      } ],\r\n" + //
+      "      \"annotationData\" : null\r\n" + //
+      "    }\r\n" + //
+      "  } ],\r\n" + //
+      "  \"typeId\" : \"aCollectionType\"\r\n" + //
       "}";
-  
+
   @Test
   public void testThat_collectionMarshallingWorks() throws JsonProcessingException {
     Collection f = createTestCollection();
-    
+
     String s = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(f);
-    
+
     assertThat(s).isEqualToIgnoringWhitespace(REF);
   }
 
@@ -104,60 +108,60 @@ public class JsonMappingTest {
     f.setDateModified(Instant.ofEpochMilli(1));
     f.setCreatedBy("user");
     f.setMetadata(objectMapper.createObjectNode().put("foo", "bar"));
-    
+
     Element e1 = new Element();
     e1.setId("anElementId");
     e1.setDateCreated(Instant.ofEpochMilli(1));
     e1.setDateModified(Instant.ofEpochMilli(1));
     e1.setTags(Arrays.asList("foo", "bar"));
     e1.setMetadata(objectMapper.createObjectNode().put("foo", "baz"));
-    
+
     Artifact a = new Artifact();
     a.setContentURI("text:collection:from://some/where");
     a.setMediaType(MediaType.TEXT_PLAIN);
     e1.setSpecification(a);
-    
+
     f.getElements().add(e1);
-    
+
     Element e2 = new Element();
     e2.setId("anotherElementId");
     e2.setDateCreated(Instant.ofEpochMilli(1));
     e2.setDateModified(Instant.ofEpochMilli(1));
     e2.setTags(Arrays.asList("foo", "bar"));
     e2.setMetadata(objectMapper.createObjectNode().put("foo", "baz"));
-    
+
     CompositePaged cp = new CompositePaged();
-    
+
     PageSequence ps1 = new PageSequence();
     ps1.setMediaType(MediaType.APPLICATION_PDF);
     ps1.setContentURI("pdf:from://some/where");
-    ps1.setPageIndices(new int[] {0,1,2});
+    ps1.setPageIndices(new int[]{0, 1, 2});
     cp.getPageSequences().add(ps1);
-    
+
     PageSequence ps2 = new PageSequence();
     ps2.setMediaType(MediaType.IMAGE_JPEG);
     ps2.setContentURI("jpg:from://some/where");
-    ps2.setPageIndices(new int[] {0});
+    ps2.setPageIndices(new int[]{0});
     cp.getPageSequences().add(ps2);
-    
+
     PageSequence ps3 = new PageSequence();
     ps3.setMediaType(MediaType.valueOf("image/tiff"));
     ps3.setContentURI("tiff:from://some/where");
-    ps3.setPageIndices(new int[] {3,4,5});
+    ps3.setPageIndices(new int[]{3, 4, 5});
     cp.getPageSequences().add(ps3);
-    
+
     e2.setSpecification(cp);
     f.getElements().add(e2);
     return f;
   }
-  
+
   @Test
   public void testThat_collectionUnmarshallingWorks() throws JsonMappingException, JsonProcessingException {
     Collection f = objectMapper.readValue(REF, Collection.class);
-    
+
     assertThat(f.getId()).isEqualTo("anId");
     assertThat(f.getVersionTimestamp()).isEqualTo(Instant.ofEpochMilli(1));
-    
+
     verifyTestCollection(f);
   }
 
@@ -169,9 +173,9 @@ public class JsonMappingTest {
     assertThat(f.getCreatedBy()).isEqualTo("user");
 
     assertThat(f.getMetadata().findPath("foo").asText()).isEqualTo("bar");
-    
+
     assertThat(f.getElements()).hasSize(2);
-    
+
     Element e1 = f.getElements().get(0);
     assertThat(e1.getId()).isEqualTo("anElementId");
     assertThat(e1.getDateCreated()).isEqualTo(Instant.ofEpochMilli(1));
@@ -186,15 +190,15 @@ public class JsonMappingTest {
 
     Element e2 = f.getElements().get(1);
     assertThat(e2.getSpecification()).isInstanceOf(CompositePaged.class);
-    
+
     CompositePaged cp = (CompositePaged) e2.getSpecification();
     assertThat(cp.getPageSequences()).hasSize(3);
-    
+
     assertThat(cp.getPageSequences().get(0).getContentURI()).isEqualTo("pdf:from://some/where");
     assertThat(cp.getPageSequences().get(0).getMediaType()).isEqualTo(MediaType.APPLICATION_PDF);
-    assertThat(cp.getPageSequences().get(0).getPageIndices()).containsExactly(0,1,2);
+    assertThat(cp.getPageSequences().get(0).getPageIndices()).containsExactly(0, 1, 2);
 
     assertThat(cp.getPageSequences().get(2).getContentURI()).isEqualTo("tiff:from://some/where");
-    assertThat(cp.getPageSequences().get(2).getPageIndices()).containsExactly(3,4,5);
+    assertThat(cp.getPageSequences().get(2).getPageIndices()).containsExactly(3, 4, 5);
   }
 }


### PR DESCRIPTION
Can be tested with https://github.com/levigo/neverpile-fusion-jwt-viewer/pull/51 and https://github.com/levigo/neverpile-fusion-web-client/pull/180